### PR TITLE
Update dfast_file_downloader.py

### DIFF
--- a/dfc/default_config.py
+++ b/dfc/default_config.py
@@ -355,6 +355,7 @@ class Config:
                 "evalue_cutoff": 1e-6,
                 "database": "@@DB_ROOT@@/hmm/TIGRFAMs_15.0_HMM.LIB",
                 "db_name": "TIGR",
+                "cmd_options": ""
             },
         },
         {
@@ -364,9 +365,10 @@ class Config:
             "options": {
                 # "cpu": 2,  # Uncomment this to set the component-specific number of CPUs, or the global setting is used.
                 "skipAnnotatedFeatures": False,
-                "evalue_cutoff": 1e-6,
+                #"evalue_cutoff": 1e-6,
                 "db_name": "",  # eg 'Pfam',
-                "database": ""  # eg '@@DB_ROOT@@/hmm/Pfam-A.hmm'
+                "database": "",  # eg '@@DB_ROOT@@/hmm/Pfam-A.hmm'
+                "cmd_options": "--cut_ga" # default search parameter used by Pfam database
             },
         },
         {

--- a/dfc/tools/hmmer.py
+++ b/dfc/tools/hmmer.py
@@ -16,10 +16,16 @@ class Hmmer_hmmscan(Tool):
         if options is None:
             options = {}
         self.evalue_cutoff = options.get("evalue_cutoff", 1e-5)
+        self.cmd_options = options.get("cmd_options", "")
 
     def get_command(self, query_file, db_name, result_file):
-        return ["hmmscan", "--noali", "--notextw", "--cpu", "1", "-E", str(self.evalue_cutoff), "--tblout", result_file,
-                db_name, query_file]
+        if self.cmd_options != "":
+            cmd = ["hmmscan", self.cmd_options, "--noali", "--notextw", "--cpu", "1", "--tblout", result_file,
+                    db_name, query_file]
+        else:
+            cmd = ["hmmscan", "--noali", "--notextw", "--cpu", "1", "-E", str(self.evalue_cutoff), "--tblout", result_file,
+                    db_name, query_file]
+        return cmd
 
 
 class Hmmer_hmmpress(Tool):

--- a/scripts/dfast_file_downloader.py
+++ b/scripts/dfast_file_downloader.py
@@ -50,8 +50,8 @@ db_urls = {
 }
 
 hmm_urls = {
-    "Pfam": "ftp://ftp.ebi.ac.uk//pub/databases/Pfam/releases/Pfam31.0/Pfam-A.hmm.gz",
-    "dbCAN": "http://bcb.unl.edu/dbCAN2/download/dbCAN-HMMdb-V9.txt",
+    "Pfam": "ftp://ftp.ebi.ac.uk//pub/databases/Pfam/releases/Pfam37.0/Pfam-A.hmm.gz",
+    "dbCAN": "http://bcb.unl.edu/dbCAN2/download/dbCAN-HMMdb-V12.txt",
     "TIGR": "https://ftp.ncbi.nlm.nih.gov/hmm/TIGRFAMs/release_15.0/TIGRFAMs_15.0_HMM.LIB.gz"
 }
 


### PR DESCRIPTION
updates dbCAN and Pfam versions to the latest.

Pfam URL could also be changed to automatically pull the latest release with `http://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz`