### PR TITLE
Fix for #58: AttributeError in PseudoGeneDetection.py with Biopython …

### DIFF
--- a/dfc/models/bio_feature.py
+++ b/dfc/models/bio_feature.py
@@ -19,6 +19,16 @@ class ExtendedFeature(SeqFeature):
         if annotations is None:
             annotations = {}
         self.annotations = annotations
+    
+    @property
+    def strand(self):
+        """
+        Alias to self.location.strand.
+        This fixes AttributeError in DFAST utility scripts when using Biopython 1.82+.
+        """
+        if self.location is not None:
+            return self.location.strand
+        return None
 
     def assign_hit(self, verbosity=2):
         if self.type == "CRISPR":


### PR DESCRIPTION
# Description 
This PR fixes the AttributeError: 'ExtendedFeature' object has no attribute 'strand' that occurs during the functional annotation step when using Biopython 1.86.

In recent versions of Biopython, attributes like strand should be accessed through the location object of a feature. I have modified dfc/models/bio_feature.py to mitigate compatibility issues while maintaining the existing logic.